### PR TITLE
pass params down to the original validator function, from the validat…

### DIFF
--- a/types.go
+++ b/types.go
@@ -23,7 +23,7 @@ func WrapOldValidatorSignature(f func(value string) bool, errKey, errMessage str
 // wraps it so it can be used with the new signature
 func WrapeOldParamValidatorSignature(f func(str string, params ...string) bool, errKey, errMessage string) ParamValidator {
 	return func(ctx context.Context, value string, params ...string) (bool, map[string]string, error) {
-		if valid := f(value); valid {
+		if valid := f(value, params...); valid {
 			return true, nil, nil
 		}
 


### PR DESCRIPTION
IS created wrappers around all validators, but for validators that take parameters the parameter were not passed down caused `length(min|max)`, `stringlength(min|max)` to always fail.

This means that for all projects currently using this fork, the validators that take parameters should be broken.

I now pass the params through the wrapper an down into the original validator function.

Did some tests with my simple playaround project api that uses this fork.

## Screenshots before changes

![Screenshot 2020-09-30 at 11 29 53](https://user-images.githubusercontent.com/35084243/94668525-73144380-0310-11eb-8b9a-135fedbcfaca.png)

## Screenshots after changes

![Screenshot 2020-09-30 at 11 24 19](https://user-images.githubusercontent.com/35084243/94668161-ff723680-030f-11eb-8f06-a5c7c342aeff.png)

![Screenshot 2020-09-30 at 11 25 35](https://user-images.githubusercontent.com/35084243/94668175-039e5400-0310-11eb-9c69-0421f209d44a.png)

![Screenshot 2020-09-30 at 11 24 19](https://user-images.githubusercontent.com/35084243/94668187-07ca7180-0310-11eb-81c3-042b9ecee774.png)
